### PR TITLE
change default lang from app to RainLab Translator

### DIFF
--- a/components/StaticMenuMultilingual.php
+++ b/components/StaticMenuMultilingual.php
@@ -31,7 +31,8 @@ class StaticMenuMultilingual extends StaticMenu
     public function menuItems()
     {
         $code = $this->property('code');
-        $locale = App::getLocale();
+        $translator	= \RainLab\Translate\Classes\Translator::instance();
+		$locale	= $translator->getLocale();
         $this->setProperty('code', $code . '-' . $locale);
         return parent::menuItems();
     }


### PR DESCRIPTION
You can set default locale in translate plugin, without change app config locale.
